### PR TITLE
Evaluating orders in the background

### DIFF
--- a/web_server_with_database/src/common_utils/global_types.rs
+++ b/web_server_with_database/src/common_utils/global_types.rs
@@ -1,5 +1,5 @@
 /* PUBLIC TYPES */
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct SubmittedOrderData {
     pub name: Option<String>,
     pub email: Option<String>,

--- a/web_server_with_database/src/common_utils/global_types.rs
+++ b/web_server_with_database/src/common_utils/global_types.rs
@@ -1,4 +1,5 @@
 /* PUBLIC TYPES */
+#[derive(Clone)]
 pub struct SubmittedOrderData {
     pub name: Option<String>,
     pub email: Option<String>,

--- a/web_server_with_database/src/database_handler/database_handler.rs
+++ b/web_server_with_database/src/database_handler/database_handler.rs
@@ -137,7 +137,18 @@ pub fn read_orders_from_db() -> Result<Vec<SubmittedOrderData>> {
  * @return Option<SubmittedOrderData> A pending order or None if no orders are pending.
  */
 pub fn get_pending_order() -> Option<SubmittedOrderData> {
-    // Placeholder for the function
+    match read_orders_from_db() {
+        Ok(orders) => {
+            if orders.is_empty() {
+                return None;
+            }
+            let order = orders[0].clone();
+            return Some(order);
+        }
+        Err(_) => {
+            println!("Error reading orders from database");
+        }
+    }
     return None;
 }
 

--- a/web_server_with_database/src/main.rs
+++ b/web_server_with_database/src/main.rs
@@ -63,11 +63,11 @@ lazy_static! {
 
 /**
  * @brief Initializes modules with command-line arguments.
- * 
+ *
  * This function initializes the database, Orca Slicer interface, and API handler
  * using the provided command-line arguments. It also updates the global state
  * with the workspace path.
- * 
+ *
  * @param args Command-line arguments parsed into an Args struct.
  */
 fn initialize_modules_with_cmd_arguments(args: Args) {
@@ -81,11 +81,11 @@ fn initialize_modules_with_cmd_arguments(args: Args) {
 
 /**
  * @brief Processes orders periodically.
- * 
+ *
  * This asynchronous function checks for pending orders at regular intervals.
  * If a pending order is found, it evaluates the order using the Orca Slicer,
  * sends the result to the client, and updates the database.
- * 
+ *
  * @param interval_seconds Interval in seconds between order checks.
  */
 async fn process_orders_periodically(interval_seconds: u64) {
@@ -96,15 +96,20 @@ async fn process_orders_periodically(interval_seconds: u64) {
         println!("Checking for pending orders...");
         match get_pending_order() {
             Some(order) => {
+                println!("{:?}", order);
                 let slicer_evaluation_result: EvaluationResult = get_orca_slicer_evaluation(&order);
                 send_result_to_client(&slicer_evaluation_result);
                 add_evaluation_to_db(slicer_evaluation_result);
                 remove_order_from_db(order);
-            }
+            },
             None => {
-                interval.tick().await;
+                println!(
+                    "No order in the database. Scheduled next check in {} seconds",
+                    interval_seconds
+                );
             }
         }
+        interval.tick().await;
     }
 }
 

--- a/web_server_with_database/src/orca_slicer_interface/orca_slicer_cli.rs
+++ b/web_server_with_database/src/orca_slicer_interface/orca_slicer_cli.rs
@@ -3,6 +3,7 @@ use std::io::{self, Write};
 use std::process::Command;
 
 /* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
 
 /* PRIVATE TYPES AND VARIABLES */
 
@@ -20,9 +21,9 @@ use std::process::Command;
  * @return io::Result<()> Result indicating success or failure of the operation.
  */
 pub fn ping_orca_slicer(orca_path: &str) -> io::Result<()> {
-    // Example command: ls the directory at orca_path
-    let output = Command::new("ls").arg(orca_path).output()?;
-
+    let output = Command::new(orca_path).arg("--help").output()?;
+    println!("{}", String::from_utf8_lossy(&output.stdout));
+    
     if output.status.success() {
         Ok(())
     } else {
@@ -33,6 +34,25 @@ pub fn ping_orca_slicer(orca_path: &str) -> io::Result<()> {
             "Failed to ping Orca Slicer",
         ))
     }
+}
+
+/**
+ * @brief Evaluates the Orca Slicer through CLI.
+ *
+ * This function interacts with the Orca Slicer executable via the command-line interface
+ * to perform an evaluation or retrieve specific information.
+ *
+ * @param order Reference to the submitted order data.
+ * @param slicer_exec_path Path to the Orca Slicer executable.
+ * @param ws_path Path to the workspace directory.
+ * @return EvaluationResult Result containing the evaluation details.
+ */
+pub fn get_orca_slicer_evaluation(
+    _order: &SubmittedOrderData,
+    _slicer_path: &str,
+    _ws_path: &str,
+) -> EvaluationResult {
+    EvaluationResult { _price: 0.0 }
 }
 
 /* TESTS */

--- a/web_server_with_database/src/orca_slicer_interface/orca_slicer_interface.rs
+++ b/web_server_with_database/src/orca_slicer_interface/orca_slicer_interface.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 
 /* IMPORTS FROM OTHER MODULES */
 use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
-use crate::orca_slicer_interface::orca_slicer_cli::ping_orca_slicer;
+use crate::orca_slicer_interface::orca_slicer_cli as orca_cli;
 
 /* PRIVATE TYPES AND VARIABLES */
 struct State {
@@ -27,11 +27,11 @@ lazy_static! {
 
 /**
  * @brief Initializes the Orca Slicer interface.
- * 
+ *
  * This function sets up the Orca Slicer interface by updating the global state
  * with the workspace path and slicer executable path. It also pings the Orca Slicer
  * to ensure it is reachable.
- * 
+ *
  * @param ws_path Path to the workspace directory.
  * @param orca_path Path to the Orca Slicer executable.
  */
@@ -42,22 +42,24 @@ pub fn initialize_orca_slicer_if(ws_path: &str, orca_path: &str) {
     *ws_path_lock = ws_path.to_string();
     *slicer_exec_path_lock = orca_path.to_string();
 
-    if let Err(e) = ping_orca_slicer(orca_path) {
+    if let Err(e) = orca_cli::ping_orca_slicer(orca_path) {
         panic!("Failed to ping Orca Slicer: {:?}", e);
     }
 }
 
 /**
  * @brief Evaluates an order using the Orca Slicer.
- * 
+ *
  * This function takes a submitted order and returns an evaluation result.
  * Currently, it returns a placeholder result.
- * 
+ *
  * @param _order Reference to the submitted order data.
  * @return EvaluationResult The result of the evaluation.
  */
-pub fn get_orca_slicer_evaluation(_order: &SubmittedOrderData) -> EvaluationResult {
-    EvaluationResult { _price: 0.0 }
+pub fn get_orca_slicer_evaluation(order: &SubmittedOrderData) -> EvaluationResult {
+    let orca_path = &*SLICER_IF_STATE.slicer_exec_path.lock().unwrap();
+    let workspace_path = &*SLICER_IF_STATE.ws_path.lock().unwrap();
+    return orca_cli::get_orca_slicer_evaluation(order, orca_path, workspace_path);
 }
 
 /* TESTS */


### PR DESCRIPTION
- Added implementation of get_pending_order()
- Fixed a bug in process_orders_periodically() where wait was not executed when get_pending_order() return None
- Added dispatching of add_evaluation_to_db() to CLI interface and added direct calls to OrcaSlicer