### PR TITLE
Modified database_handler and prusa_slicer_interface o use dependency injection and mocks

### DIFF
--- a/web_server_with_database/src/common_utils/global_traits.rs
+++ b/web_server_with_database/src/common_utils/global_traits.rs
@@ -1,7 +1,7 @@
 use crate::common_utils::global_types::{SubmittedOrderData, EvaluationResult};
 use std::io::{self};
 
-pub trait SlicerInterfaceImpl {
+pub trait SlicerInterfaceImpl: Send + Sync {
     fn ping(&self, prusa_path: &str) -> io::Result<()>;
     fn evaluate(&self, order: &SubmittedOrderData, slicer_path: &str, ws_path: &str) -> EvaluationResult;
 }

--- a/web_server_with_database/src/common_utils/global_traits.rs
+++ b/web_server_with_database/src/common_utils/global_traits.rs
@@ -1,0 +1,7 @@
+use crate::common_utils::global_types::{SubmittedOrderData, EvaluationResult};
+use std::io::{self};
+
+pub trait SlicerInterfaceImpl {
+    fn ping(&self, prusa_path: &str) -> io::Result<()>;
+    fn evaluate(&self, order: &SubmittedOrderData, slicer_path: &str, ws_path: &str) -> EvaluationResult;
+}

--- a/web_server_with_database/src/common_utils/global_traits.rs
+++ b/web_server_with_database/src/common_utils/global_traits.rs
@@ -1,7 +1,14 @@
 use crate::common_utils::global_types::{SubmittedOrderData, EvaluationResult};
-use std::io::{self};
+use std::io::Result;
 
 pub trait SlicerInterfaceImpl: Send + Sync {
-    fn ping(&self, prusa_path: &str) -> io::Result<()>;
+    fn ping(&self, prusa_path: &str) -> Result<()>;
     fn evaluate(&self, order: &SubmittedOrderData, slicer_path: &str, ws_path: &str) -> EvaluationResult;
+}
+
+pub trait DatabaseInterfaceImpl: Send + Sync {
+    fn initialize_db(&self, db_name: &str) -> Result<()>;
+    fn add_form_submission_to_db(&self, form_fields: SubmittedOrderData) -> Result<()>;
+    fn read_orders_from_db(&self) -> Result<Vec<SubmittedOrderData>>;
+    fn get_pending_order(&self) -> Option<SubmittedOrderData>;
 }

--- a/web_server_with_database/src/common_utils/mod.rs
+++ b/web_server_with_database/src/common_utils/mod.rs
@@ -1,4 +1,5 @@
 // PUBLIC MODULES
 pub mod global_types;
+pub mod global_traits;
 
 // PRIVATE MODULES

--- a/web_server_with_database/src/database_handler/database_handler.rs
+++ b/web_server_with_database/src/database_handler/database_handler.rs
@@ -1,39 +1,27 @@
 /* IMPORTS FROM LIBRARIES */
 use lazy_static::lazy_static;
-use rusqlite::{Connection, Result};
 use std::sync::Mutex;
+use std::io::Result;
 
 /* IMPORTS FROM OTHER MODULES */
 use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
+use crate::common_utils::global_traits::DatabaseInterfaceImpl;
+use crate::database_handler::database_sqlite_impl::DatabaseSQLiteImpl;
 
 /* PRIVATE TYPES AND VARIABLES */
 struct State {
-    db_name: Mutex<String>,
-    db_conn: Mutex<Option<Connection>>,
+    db_impl: Mutex<Box<dyn DatabaseInterfaceImpl>>,
 }
 
 lazy_static! {
     static ref DB_HANDLER_STATE: State = State {
-        db_name: Mutex::new(String::from("")),
-        db_conn: Mutex::new(None),
+        db_impl: Mutex::new(Box::new(DatabaseSQLiteImpl { db_conn: Mutex::new(None) })),
     };
 }
 
 /* PUBLIC TYPES AND VARIABLES */
 
 /* PRIVATE FUNCTIONS */
-fn write_submission_to_db(name: &str, email: &str, copes_nbr: &str, file_name: &str) -> bool {
-    let db_conn = DB_HANDLER_STATE.db_conn.lock().unwrap();
-    let conn = db_conn
-        .as_ref()
-        .expect("Database connection is not initialized");
-
-    conn.execute(
-        "INSERT INTO Orders (name, email, copies_nbr, file_name) VALUES (?1, ?2, ?3, ?4)",
-        &[&name, &email, copes_nbr, &file_name],
-    )
-    .is_ok()
-}
 
 /* PUBLIC FUNCTIONS */
 
@@ -46,20 +34,8 @@ fn write_submission_to_db(name: &str, email: &str, copes_nbr: &str, file_name: &
  * @param db_name Name of the database file.
  */
 pub fn initialize_db(db_name: &str) {
-    let mut db_name_lock = DB_HANDLER_STATE.db_name.lock().unwrap();
-    *db_name_lock = db_name.to_string();
-    let conn = Connection::open(db_name).expect("Failed to open database");
-    conn.execute(
-        "create table if not exists Orders (
-            name text not null,
-            email text not null,
-            copies_nbr integer not null,
-            file_name text not null)",
-        [],
-    )
-    .expect("Failed to create Orders table");
-    let mut db_conn = DB_HANDLER_STATE.db_conn.lock().unwrap();
-    *db_conn = Some(conn);
+    let database_handler_impl = DB_HANDLER_STATE.db_impl.lock().unwrap();
+    database_handler_impl.initialize_db(db_name).expect("Failed to initialize database");
 }
 
 /**
@@ -71,29 +47,12 @@ pub fn initialize_db(db_name: &str) {
  * @return bool True if the submission was successfully added, false otherwise.
  */
 pub fn add_form_submission_to_db(form_fields: SubmittedOrderData) -> bool {
-    let name = match form_fields.name {
-        Some(name) => name,
-        None => return false,
-    };
-    let email = match form_fields.email {
-        Some(email) => email,
-        None => return false,
-    };
-    if form_fields.copies_nbr < 1 {
-        return false;
+    let database_handler_impl = DB_HANDLER_STATE.db_impl.lock().unwrap();
+    match database_handler_impl.add_form_submission_to_db(form_fields)
+    {
+        Ok(_) => return true,
+        Err(_) => return false,
     }
-    let file_name = match form_fields.file_name {
-        Some(file_name) => file_name,
-        None => return false,
-    };
-    write_submission_to_db(
-        name.as_str(),
-        email.as_str(),
-        form_fields.copies_nbr.to_string().as_str(),
-        file_name.as_str(),
-    );
-
-    return true;
 }
 
 /**
@@ -106,27 +65,8 @@ pub fn add_form_submission_to_db(form_fields: SubmittedOrderData) -> bool {
  *         if successful, or an error if the operation fails.
  */
 pub fn read_orders_from_db() -> Result<Vec<SubmittedOrderData>> {
-    let db_conn = DB_HANDLER_STATE.db_conn.lock().unwrap();
-    let conn = db_conn
-        .as_ref()
-        .expect("Database connection is not initialized");
-
-    let mut stmt = conn.prepare("SELECT name, email, copies_nbr, file_name FROM Orders")?;
-    let order_iter = stmt.query_map([], |row| {
-        Ok(SubmittedOrderData {
-            name: Some(row.get(0)?),
-            email: Some(row.get(1)?),
-            copies_nbr: row.get(2)?,
-            file_name: Some(row.get(3)?),
-        })
-    })?;
-
-    let mut orders = Vec::new();
-    for order in order_iter {
-        orders.push(order?);
-    }
-
-    Ok(orders)
+    let database_handler_impl = DB_HANDLER_STATE.db_impl.lock().unwrap();
+    return database_handler_impl.read_orders_from_db();
 }
 
 /**
@@ -137,19 +77,8 @@ pub fn read_orders_from_db() -> Result<Vec<SubmittedOrderData>> {
  * @return Option<SubmittedOrderData> A pending order or None if no orders are pending.
  */
 pub fn get_pending_order() -> Option<SubmittedOrderData> {
-    match read_orders_from_db() {
-        Ok(orders) => {
-            if orders.is_empty() {
-                return None;
-            }
-            let order = orders[0].clone();
-            return Some(order);
-        }
-        Err(_) => {
-            println!("Error reading orders from database");
-        }
-    }
-    return None;
+    let database_handler_impl = DB_HANDLER_STATE.db_impl.lock().unwrap();
+    return database_handler_impl.get_pending_order();
 }
 
 /**
@@ -178,93 +107,31 @@ pub fn remove_order_from_db(_order: SubmittedOrderData) {
 /* TESTS */
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use std::fs;
-    use std::path::Path;
+use super::*;
+use crate::database_handler::database_mock::DatabaseMockImpl;
+
+    /// Helper function to reset the global state
+    fn reset_state_and_setup_mocked_interface() {
+        let mut db_impl_lock = DB_HANDLER_STATE.db_impl.lock().unwrap();
+        *db_impl_lock = Box::new(DatabaseMockImpl {});
+    }
 
     #[test]
     fn test_initialize_db() {
-        let db_name = "test_db.sqlite";
-
-        // Ensure the test database file does not exist before the test
-        if Path::new(db_name).exists() {
-            fs::remove_file(db_name).expect("Failed to delete existing test database file");
-        }
-
-        // Call the function to initialize the database
-        initialize_db(db_name);
-
-        // Check if the database file was created
-        assert!(Path::new(db_name).exists(), "Database file was not created");
-
-        // Check if the table was created
-        {
-            let db_conn = DB_HANDLER_STATE.db_conn.lock().unwrap();
-            let conn = db_conn
-                .as_ref()
-                .expect("Database connection is not initialized");
-            let mut stmt = conn
-                .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name='Orders'")
-                .expect("Failed to prepare statement");
-            let table_exists = stmt.exists([]).expect("Failed to execute query");
-            assert!(table_exists, "Orders table was not created");
-        }
-
-        // Clean up the test database file
-        if let Err(e) = fs::remove_file(db_name) {
-            eprintln!("Failed to delete test database file: {}", e);
-        }
+        reset_state_and_setup_mocked_interface();
+        initialize_db("test_db");
     }
 
     #[test]
     fn test_add_form_submission_to_db() {
-        let db_name = "test_db.sqlite";
-
-        // Ensure the test database file does not exist before the test
-        if Path::new(db_name).exists() {
-            fs::remove_file(db_name).expect("Failed to delete existing test database file");
-        }
-
-        // Initialize the database
-        initialize_db(db_name);
-
-        // Create a SubmittedOrderData instance
-        let form_fields = SubmittedOrderData {
-            name: Some(String::from("John Doe")),
-            email: Some(String::from("john.doe@example.com")),
+        reset_state_and_setup_mocked_interface();
+        let order = SubmittedOrderData {
+            name: Some("John Doe".to_string()),
+            email: Some("john.doe@example.com".to_string()),
             copies_nbr: 5,
-            file_name: Some(String::from("file.txt")),
+            file_name: Some("file.stl".to_string()),
         };
-
-        // Add form submission to the database
-        let result = add_form_submission_to_db(form_fields);
-        assert!(result, "Failed to add form submission to the database");
-
-        // Clean up the test database file
-        if let Err(e) = fs::remove_file(db_name) {
-            eprintln!("Failed to delete test database file: {}", e);
-        }
+        assert!(add_form_submission_to_db(order) == true);
     }
 
-    #[test]
-    fn test_write_submission_to_db() {
-        let db_name = "test_db.sqlite";
-
-        // Ensure the test database file does not exist before the test
-        if Path::new(db_name).exists() {
-            fs::remove_file(db_name).expect("Failed to delete existing test database file");
-        }
-
-        // Initialize the database
-        initialize_db(db_name);
-
-        // Write submission to the database
-        let result = write_submission_to_db("John Doe", "john.doe@example.com", "5", "file.txt");
-        assert!(result, "Failed to write submission to the database");
-
-        // Clean up the test database file
-        if let Err(e) = fs::remove_file(db_name) {
-            eprintln!("Failed to delete test database file: {}", e);
-        }
-    }
 }

--- a/web_server_with_database/src/database_handler/database_mock.rs
+++ b/web_server_with_database/src/database_handler/database_mock.rs
@@ -1,0 +1,33 @@
+/* IMPORTS FROM LIBRARIES */
+use std::io;
+
+/* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_traits::DatabaseInterfaceImpl;
+use crate::common_utils::global_types::SubmittedOrderData;
+
+/* PRIVATE TYPES AND VARIABLES */
+/* PUBLIC TYPES AND VARIABLES */
+pub struct DatabaseMockImpl {
+}
+
+/* PRIVATE FUNCTIONS */
+
+/* PUBLIC FUNCTIONS */
+impl DatabaseInterfaceImpl for DatabaseMockImpl {
+    fn initialize_db(&self, _db_name: &str) -> io::Result<()> {
+        return Ok(());
+    }
+
+    fn add_form_submission_to_db(&self, _form_fields: SubmittedOrderData) -> io::Result<()> {
+        return Ok(());
+    }
+
+    fn read_orders_from_db(&self) -> io::Result<Vec<SubmittedOrderData>> {
+        let orders = Vec::new();
+        return Ok(orders);
+    }
+
+    fn get_pending_order(&self) -> Option<SubmittedOrderData> {
+        return None;
+    }
+}

--- a/web_server_with_database/src/database_handler/database_sqlite_impl.rs
+++ b/web_server_with_database/src/database_handler/database_sqlite_impl.rs
@@ -1,0 +1,117 @@
+/* IMPORTS FROM LIBRARIES */
+use rusqlite::Connection;
+use std::io;
+use std::sync::Mutex;
+
+/* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_traits::DatabaseInterfaceImpl;
+use crate::common_utils::global_types::SubmittedOrderData;
+
+/* PRIVATE TYPES AND VARIABLES */
+/* PUBLIC TYPES AND VARIABLES */
+pub struct DatabaseSQLiteImpl {
+    pub db_conn: Mutex<Option<Connection>>,
+}
+
+/* PRIVATE FUNCTIONS */
+fn write_submission_to_db(db_conn: &Connection ,name: &str, email: &str, copes_nbr: &str, file_name: &str) -> bool {
+    db_conn.execute(
+        "INSERT INTO Orders (name, email, copies_nbr, file_name) VALUES (?1, ?2, ?3, ?4)",
+        &[&name, &email, copes_nbr, &file_name],
+    )
+    .is_ok()
+}
+
+/* PUBLIC FUNCTIONS */
+impl DatabaseInterfaceImpl for DatabaseSQLiteImpl {
+    fn initialize_db(&self, db_name: &str) -> io::Result<()> {
+        let conn = Connection::open(db_name).expect("Failed to open database");
+        conn.execute(
+            "create table if not exists Orders (
+            name text not null,
+            email text not null,
+            copies_nbr integer not null,
+            file_name text not null)",
+            [],
+        )
+        .expect("Failed to create Orders table");
+        let mut db_conn = self.db_conn.lock().unwrap();
+        *db_conn = Some(conn);
+        return Ok(());
+    }
+
+    fn add_form_submission_to_db(&self, form_fields: SubmittedOrderData) -> io::Result<()> {
+        let name = match form_fields.name {
+            Some(name) => name,
+            None => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Missing name")),
+        };
+        let email = match form_fields.email {
+            Some(email) => email,
+            None => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Missing email")),
+        };
+        if form_fields.copies_nbr < 1 {
+            return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid number of copies"));
+        }
+        let file_name = match form_fields.file_name {
+            Some(file_name) => file_name,
+            None => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Missing file name")),
+        };
+        let db_conn = self.db_conn.lock().unwrap();
+        let conn = db_conn.as_ref().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::NotConnected, "Database connection is not initialized")
+        })?;
+        if !write_submission_to_db(
+            conn,
+            name.as_str(),
+            email.as_str(),
+            form_fields.copies_nbr.to_string().as_str(),
+            file_name.as_str(),
+        ) {
+            return Err(io::Error::new(io::ErrorKind::Other, "Failed to write to database"));
+        }
+        Ok(())
+    }
+
+    fn read_orders_from_db(&self) -> io::Result<Vec<SubmittedOrderData>> {
+        let db_conn = self.db_conn.lock().unwrap();
+        let conn = db_conn
+            .as_ref()
+            .ok_or_else(|| io::Error::new(io::ErrorKind::NotConnected, "Database connection is not initialized"))?;
+
+        let mut stmt = conn
+            .prepare("SELECT name, email, copies_nbr, file_name FROM Orders")
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Failed to prepare statement: {}", e)))?;
+        let order_iter = stmt
+            .query_map([], |row| {
+                Ok(SubmittedOrderData {
+                    name: Some(row.get(0)?),
+                    email: Some(row.get(1)?),
+                    copies_nbr: row.get(2)?,
+                    file_name: Some(row.get(3)?),
+                })
+            })
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Failed to query rows: {}", e)))?;
+
+        let mut orders = Vec::new();
+        for order in order_iter {
+            orders.push(order.map_err(|e| io::Error::new(io::ErrorKind::Other, format!("Failed to map row: {}", e)))?);
+        }
+        Ok(orders)
+    }
+
+    fn get_pending_order(&self) -> Option<SubmittedOrderData> {
+        match self.read_orders_from_db() {
+            Ok(orders) => {
+                if orders.is_empty() {
+                    return None;
+                }
+                let order = orders[0].clone();
+                return Some(order);
+            }
+            Err(_) => {
+                println!("Error reading orders from database");
+            }
+        }
+        return None;
+    }
+}

--- a/web_server_with_database/src/database_handler/mod.rs
+++ b/web_server_with_database/src/database_handler/mod.rs
@@ -3,3 +3,5 @@ pub mod database_handler;
 pub use database_handler::*;
 
 // PRIVATE MODULES
+mod database_mock;
+mod database_sqlite_impl;

--- a/web_server_with_database/src/main.rs
+++ b/web_server_with_database/src/main.rs
@@ -73,7 +73,8 @@ lazy_static! {
 fn initialize_modules_with_cmd_arguments(args: Args) {
     // This consumes the args struct and initializes the global state. No other use of args is allowed after this point.
     initialize_db(&args.db_name);
-    initialize_prusa_slicer_if(&args.system, &args.prusa_path);
+    initialize_prusa_slicer_if(&args.system, &args.prusa_path)
+        .expect("Failed to initialize Prusa Slicer interface");
     let mut ws_path_lock = MAIN_STATE.ws_path.lock().unwrap();
     *ws_path_lock = args.ws_path.to_string();
     initialize_api_handler(true);
@@ -97,11 +98,12 @@ async fn process_orders_periodically(interval_seconds: u64) {
         match get_pending_order() {
             Some(order) => {
                 println!("{:?}", order);
-                let slicer_evaluation_result: EvaluationResult = get_prusa_slicer_evaluation(&order);
+                let slicer_evaluation_result: EvaluationResult =
+                    get_prusa_slicer_evaluation(&order);
                 send_result_to_client(&slicer_evaluation_result);
                 add_evaluation_to_db(slicer_evaluation_result);
                 remove_order_from_db(order);
-            },
+            }
             None => {
                 println!(
                     "No order in the database. Scheduled next check in {} seconds",

--- a/web_server_with_database/src/prusa_slicer_interface/mod.rs
+++ b/web_server_with_database/src/prusa_slicer_interface/mod.rs
@@ -4,3 +4,4 @@ pub use prusa_slicer_interface::*;
 
 // PRIVATE MODULES
 mod prusa_slicer_cli;
+mod prusa_slicer_mock;

--- a/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_cli.rs
+++ b/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_cli.rs
@@ -3,55 +3,60 @@ use std::io::{self, Write};
 use std::process::Command;
 
 /* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_traits::SlicerInterfaceImpl;
 use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
 
 /* PRIVATE TYPES AND VARIABLES */
 
 /* PUBLIC TYPES AND VARIABLES */
+pub struct PrusaSlicerCli;
 
 /* PRIVATE FUNCTIONS */
 
 /* PUBLIC FUNCTIONS */
-/**
- * @brief Pings the Prusa Slicer executable.
- *
- * This function checks if the Prusa Slicer executable is reachable by running a command.
- *
- * @param prusa_path Path of Prusa Slicer
- * @return io::Result<()> Result indicating success or failure of the operation.
- */
-pub fn ping_prusa_slicer(prusa_path: &str) -> io::Result<()> {
-    let output = Command::new(prusa_path).arg("--help").output()?;
-    if output.status.success() {
-        Ok(())
-    } else {
-        io::stderr().write_all(&output.stderr)?;
-        println!("Failed to ping Prusa Slicer at path: {:?}", prusa_path);
-        Err(io::Error::new(
-            io::ErrorKind::Other,
-            "Failed to ping Prusa Slicer",
-        ))
+impl SlicerInterfaceImpl for PrusaSlicerCli {
+    /**
+     * @brief Pings the Prusa Slicer executable.
+     *
+     * This function checks if the Prusa Slicer executable is reachable by running a command.
+     *
+     * @param prusa_path Path of Prusa Slicer
+     * @return io::Result<()> Result indicating success or failure of the operation.
+     */
+    fn ping(&self, prusa_path: &str) -> io::Result<()> {
+        let output = Command::new(prusa_path).arg("--help").output()?;
+        if output.status.success() {
+            Ok(())
+        } else {
+            io::stderr().write_all(&output.stderr)?;
+            println!("Failed to ping Prusa Slicer at path: {:?}", prusa_path);
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Failed to ping Prusa Slicer",
+            ))
+        }
     }
-}
 
-/**
- * @brief Evaluates the Prusa Slicer through CLI.
- *
- * This function interacts with the Prusa Slicer executable via the command-line interface
- * to perform an evaluation or retrieve specific information.
- *
- * @param order Reference to the submitted order data.
- * @param slicer_exec_path Path to the Prusa Slicer executable.
- * @param ws_path Path to the workspace directory.
- * @return EvaluationResult Result containing the evaluation details.
- */
-pub fn get_prusa_slicer_evaluation(
-    _order: &SubmittedOrderData,
-    _slicer_path: &str,
-    _ws_path: &str,
-) -> EvaluationResult {
-    // prusa-slicer -g --load prusa_config.ini --output sliced.gcode '/Users/username/Projects/rust_project/web_server_with_database/data_files/received_orders/stl_file.stl'
-    EvaluationResult { _price: 0.0 }
+    /**
+     * @brief Evaluates the Prusa Slicer through CLI.
+     *
+     * This function interacts with the Prusa Slicer executable via the command-line interface
+     * to perform an evaluation or retrieve specific information.
+     *
+     * @param order Reference to the submitted order data.
+     * @param slicer_exec_path Path to the Prusa Slicer executable.
+     * @param ws_path Path to the workspace directory.
+     * @return EvaluationResult Result containing the evaluation details.
+     */
+    fn evaluate(
+        &self,
+        _order: &SubmittedOrderData,
+        _slicer_path: &str,
+        _ws_path: &str,
+    ) -> EvaluationResult {
+        // prusa-slicer -g --load prusa_config.ini --output sliced.gcode '/Users/username/Projects/rust_project/web_server_with_database/data_files/received_orders/stl_file.stl'
+        EvaluationResult { _price: 0.0 }
+    }
 }
 
 /* TESTS */

--- a/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_interface.rs
+++ b/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_interface.rs
@@ -1,83 +1,92 @@
 /* IMPORTS FROM LIBRARIES */
 use lazy_static::lazy_static;
+use std::io;
 use std::sync::Mutex;
 
 /* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_traits::SlicerInterfaceImpl;
 use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
 use crate::prusa_slicer_interface::prusa_slicer_cli::PrusaSlicerCli;
-use crate::common_utils::global_traits::SlicerInterfaceImpl;
 
 /* PRIVATE TYPES AND VARIABLES */
 struct State {
     ws_path: Mutex<Option<String>>,
     slicer_exec_path: Mutex<Option<String>>,
-    slicer_interface: Mutex<Box<SlicerInterfaceImpl>>,
+    slicer_interface: Mutex<Box<dyn SlicerInterfaceImpl>>,
 }
 
-
-static SLICER_IF_STATE: State = State {
-    ws_path: Mutex::new(None),
-    slicer_exec_path: Mutex::new(None),
-    slicer_interface: Mutex::new(Box::new(None)),
-};
-
-/* PUBLIC TYPES AND VARIABLES */
+lazy_static! {
+    static ref SLICER_IF_STATE: State = State {
+        ws_path: Mutex::new(None),
+        slicer_exec_path: Mutex::new(None),
+        slicer_interface: Mutex::new(Box::new(PrusaSlicerCli {})),
+    };
+}
 
 /* PRIVATE FUNCTIONS */
-
-/* PUBLIC FUNCTIONS */
-
-/**
- * @brief Initializes the Prusa Slicer interface.
- *
- * This function sets up the Prusa Slicer interface by updating the global state
- * with the workspace path and slicer executable path. It also pings the Prusa Slicer
- * to ensure it is reachable.
- *
- * @param ws_path Path to the workspace directory.
- * @param prusa_path Path to the Prusa Slicer executable.
- */
-pub fn initialize_prusa_slicer_if(ws_path: &str, prusa_path: &str) {
+fn setup_module_state(
+    ws_path: &str,
+    prusa_path: &str,
+) -> io::Result<()> {
     let mut ws_path_lock = SLICER_IF_STATE.ws_path.lock().unwrap();
     let mut slicer_exec_path_lock = SLICER_IF_STATE.slicer_exec_path.lock().unwrap();
+
+    *ws_path_lock = Some(ws_path.to_string());
+    *slicer_exec_path_lock = Some(prusa_path.to_string());
+
+    Ok(())
+}
+
+/* PUBLIC FUNCTIONS */
+pub fn initialize_prusa_slicer_if(ws_path: &str, prusa_path: &str) {
+    if let Err(e) = setup_module_state(ws_path, prusa_path) {
+        panic!("Failed to setup Prusa Slicer Interface: {:?}", e);
+    }
+
     let slicer_interface_lock = SLICER_IF_STATE.slicer_interface.lock().unwrap();
-
-    *ws_path_lock = ws_path.to_string();
-    *slicer_exec_path_lock = prusa_path.to_string();
-
-    if let Err(e) = *slicer_interface_lock.ping(prusa_path) {
+    if let Err(e) = slicer_interface_lock.ping(prusa_path) {
         panic!("Failed to ping Prusa Slicer: {:?}", e);
     }
 }
 
-/**
- * @brief Evaluates an order using the Prusa Slicer.
- *
- * This function takes a submitted order and returns an evaluation result.
- * Currently, it returns a placeholder result.
- *
- * @param _order Reference to the submitted order data.
- * @return EvaluationResult The result of the evaluation.
- */
 pub fn get_prusa_slicer_evaluation(order: &SubmittedOrderData) -> EvaluationResult {
     let prusa_path = &*SLICER_IF_STATE.slicer_exec_path.lock().unwrap();
     let workspace_path = &*SLICER_IF_STATE.ws_path.lock().unwrap();
     let slicer_interface_lock = SLICER_IF_STATE.slicer_interface.lock().unwrap();
-    return *slicer_interface_lock.evaluate(order, prusa_path, workspace_path);
+    slicer_interface_lock.evaluate(
+        order,
+        prusa_path.as_deref().unwrap(),
+        workspace_path.as_deref().unwrap(),
+    )
 }
 
+#[cfg(test)]
 mod tests {
-    // use super::*;
+    use super::*;
+    use crate::prusa_slicer_interface::prusa_slicer_mock::PrusaSlicerMock;
 
     #[test]
     fn test_initialize_prusa_slicer_if() {
-        //TBA
-        // initialize_prusa_slicer_if("new_ws_path", "new_prusa_path");
+        println!("FOO begin");
 
-        // let ws_path_lock = SLICER_IF_STATE.ws_path.lock().unwrap();
-        // let slicer_exec_path_lock = SLICER_IF_STATE.slicer_exec_path.lock().unwrap();
 
-        // assert_eq!(*ws_path_lock, "new_ws_path");
-        // assert_eq!(*slicer_exec_path_lock, "new_prusa_path");
+        {
+            let mut slicer_interface_lock = SLICER_IF_STATE.slicer_interface.lock().unwrap();
+            let mocked_interface = Box::new(PrusaSlicerMock {
+                price_to_return: 42.0,
+                ping_result: true,
+            });
+            *slicer_interface_lock = mocked_interface;
+        }
+
+        let ws_path = "foobar";
+        let prusa_path = "foobar";
+        assert!(setup_module_state(ws_path, prusa_path).is_ok());
+
+        {
+            let slicer_interface_lock = SLICER_IF_STATE.slicer_interface.lock().unwrap();
+            assert!(slicer_interface_lock.ping(prusa_path).is_ok());
+        }
+        println!("FOO1");
     }
 }

--- a/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_mock.rs
+++ b/web_server_with_database/src/prusa_slicer_interface/prusa_slicer_mock.rs
@@ -1,0 +1,42 @@
+/* IMPORTS FROM LIBRARIES */
+use std::io;
+
+/* IMPORTS FROM OTHER MODULES */
+use crate::common_utils::global_traits::SlicerInterfaceImpl;
+use crate::common_utils::global_types::{EvaluationResult, SubmittedOrderData};
+
+/* PRIVATE TYPES AND VARIABLES */
+
+/* PUBLIC TYPES AND VARIABLES */
+pub struct PrusaSlicerMock
+{
+    pub price_to_return: f64,
+    pub ping_result: bool,
+}
+
+/* PRIVATE FUNCTIONS */
+
+/* PUBLIC FUNCTIONS */
+impl SlicerInterfaceImpl for PrusaSlicerMock {
+    fn ping(&self, _prusa_path: &str) -> io::Result<()> {
+        if self.ping_result {
+            Ok(())
+        } else {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "Error returned from mocked ping() function",
+            ))
+        }
+    }
+
+    fn evaluate(
+        &self,
+        _order: &SubmittedOrderData,
+        _slicer_path: &str,
+        _ws_path: &str,
+    ) -> EvaluationResult {
+        EvaluationResult { _price: self.price_to_return }
+    }
+}
+
+/* TESTS */


### PR DESCRIPTION
Separated the interface of database_handler and prusa_slicer from implementation.
Then followed dependency injection pattern to be able to replace implementations with mocks.